### PR TITLE
Fix async session retrieval

### DIFF
--- a/src/lib/context.ts
+++ b/src/lib/context.ts
@@ -15,7 +15,7 @@ export async function buildContext(
   res: NextApiResponse,
 ): Promise<GraphQLContext> {
   // Grab the session that withApiAuthRequired validated
-  const session = getSession(req, res);
+  const session = await getSession(req, res);
   if (!session?.user?.sub) {
     throw new Error('Unauthenticated');
   }

--- a/src/pages/api/auth/me.ts
+++ b/src/pages/api/auth/me.ts
@@ -6,7 +6,7 @@ export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse,
 ) {
-  const session = getSession(req, res);
+  const session = await getSession(req, res);
   if (!session) return res.status(401).json({ error: 'unauthenticated' });
   return res.status(200).json(session.user);
 }


### PR DESCRIPTION
## Summary
- await `getSession` in API route and context

## Testing
- `npm test` *(fails: cross-env not found)*